### PR TITLE
update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You must have the [elm platform](http://elm-lang.org/install) installed as well 
 # Running the thing
 Compile the elm file into javascript. 
 ```bash
-elm-make src/Todo.elm
+elm-make src/Todo.elm --output elm.js
 ```
 
 Then run electron on the current directory.


### PR DESCRIPTION
When following the README instructions, the electron app would open and
display the following error:

```
Port Error:

    No argument was given for the port named 'getStorage' with type:

        Maybe.Maybe Todo.Model

    You need to provide an initial value!

    Find out more about ports here <http://elm-lang.org/learn/Ports.elm>

Open the developer console for more details.
```

Adding `--output elm.js` to the `elm-make` command fixed it for me. I am
using elm 0.16.0.
